### PR TITLE
Fix editor rotation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
           "branch": null,
-          "revision": "2235a22ca249199cb736237f4bb9cc12b6ed416a",
-          "version": "7.3.0"
+          "revision": "c75584ac759cbb16b204d0a7de3ebf53ea6b304d",
+          "version": "7.9.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/AnyImageKit/Editor/Protocol/EditorPhotoResource.swift
+++ b/Sources/AnyImageKit/Editor/Protocol/EditorPhotoResource.swift
@@ -16,7 +16,7 @@ public protocol EditorPhotoResource {
 extension UIImage: EditorPhotoResource {
     
     public func loadImage(completion: @escaping (Result<UIImage, AnyImageError>) -> Void) {
-        completion(.success(self))
+        completion(.success(adjustImage(self)))
     }
 }
 
@@ -27,7 +27,7 @@ extension URL: EditorPhotoResource {
             do {
                 let data = try Data(contentsOf: self)
                 if let image = UIImage(data: data) {
-                    completion(.success(image))
+                    completion(.success(adjustImage(image)))
                 } else {
                     completion(.failure(.invalidImage))
                 }
@@ -48,16 +48,16 @@ extension PHAsset: EditorPhotoResource {
             completion(.failure(.invalidMediaType))
             return
         }
-        ExportTool.requestPhoto(for: self, options: .init(size: limitSize)) { [weak self] (result, _) in
+        ExportTool.requestPhoto(for: self, options: .init(size: limitSize)) { [unowned self] (result, _) in
             switch result {
             case .success(let response):
                 if !response.isDegraded {
-                    completion(.success(response.image))
+                    completion(.success(self.adjustImage(response.image)))
                 }
             case .failure(let error):
                 completion(.failure(error))
                 if error == .cannotFindInLocal {
-                    self?.loadImageFromNetwork(completion: completion)
+                    self.loadImageFromNetwork(completion: completion)
                 }
             }
         }
@@ -74,7 +74,7 @@ extension PHAsset: EditorPhotoResource {
                     return
                 }
                 DispatchQueue.main.async {
-                    completion(.success(resizedImage))
+                    completion(.success(self.adjustImage(resizedImage)))
                 }
             case .failure(let error):
                 DispatchQueue.main.async {
@@ -89,5 +89,92 @@ extension PHAsset: EditorPhotoResource {
         size.width *= UIScreen.main.scale
         size.height *= UIScreen.main.scale
         return size
+    }
+}
+
+
+extension EditorPhotoResource {
+
+    /// Preprocess the images before starting editing.
+    fileprivate func adjustImage(_ sourceImage: UIImage) -> UIImage {
+        return fixOrientationAndRotateToUp(sourceImage)
+    }
+    
+    /// Fix orientation and rotate the image to upright position
+    private func fixOrientationAndRotateToUp(_ sourceImage: UIImage) -> UIImage {
+        guard let imageRef = sourceImage.cgImage else {
+            return sourceImage
+        }
+        
+        var rotationAngle: CGFloat = 0.0
+        var mirrored = false
+        var imageSize = sourceImage.size
+        var canvasSize = CGSize(width: imageRef.width, height: imageRef.height)
+        
+        // Get EXIF property information.
+        if let imageData = sourceImage.jpegData(compressionQuality: 0.1),
+           let imageSource = CGImageSourceCreateWithData(imageData as CFData, nil),
+           let exifProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [String: Any],
+           let orientationValue = exifProperties[kCGImagePropertyTIFFOrientation as String] as? UInt32 {
+            let orientation = CGImagePropertyOrientation(rawValue: orientationValue) ?? .up
+            rotationAngle = getRotationAngleFromImageOrientation(orientation)
+            mirrored = orientation == .upMirrored || orientation == .downMirrored ||
+                       orientation == .leftMirrored || orientation == .rightMirrored
+            let isLandscapeMode = orientation == .left || orientation == .leftMirrored ||
+                                  orientation == .right || orientation == .rightMirrored
+            
+            let newSize = CGRect(origin: .zero, size: sourceImage.size).applying(CGAffineTransform(rotationAngle: rotationAngle)).size
+            canvasSize.width = floor(newSize.width)
+            canvasSize.height = floor(newSize.height)
+            canvasSize = canvasSize.reversed(isLandscapeMode)
+            imageSize = imageSize.reversed(isLandscapeMode)
+        }
+        print(Date().timeIntervalSince1970)
+        
+        // Correcting image orientation
+        let fixedImage = UIGraphicsImageRenderer.init(size: canvasSize, format: getImageRendererFormat()).image { rendererContext in
+            let context = rendererContext.cgContext
+            
+            context.saveGState()
+            context.translateBy(x: canvasSize.width/2, y: canvasSize.height/2)
+            context.scaleBy(x: mirrored ? -1 : 1, y: -1)
+            context.rotate(by: rotationAngle)
+            context.draw(imageRef, in: CGRect(x: -imageSize.width/2, y: -imageSize.height/2, width: imageSize.width, height: imageSize.height))
+            context.restoreGState()
+        }
+        
+        return fixedImage
+    }
+    
+    /// Read the EXIF properties and return the rotation angle of the image in radians.
+    private func getRotationAngleFromImageOrientation(_ orientation: CGImagePropertyOrientation) -> CGFloat {
+        let pi = CGFloat.pi
+        switch orientation {
+        case .up, .upMirrored:
+            return 0.0
+        case .down, .downMirrored:
+            return pi
+        case .left, .rightMirrored:
+            return (pi / 2)
+        case .right, .leftMirrored:
+            return -(pi / 2)
+        }
+    }
+    
+    private func getImageRendererFormat() -> UIGraphicsImageRendererFormat {
+        let format: UIGraphicsImageRendererFormat
+        if #available(iOS 11.0, *) {
+            format = UIGraphicsImageRendererFormat.preferred()
+        } else {
+            format = UIGraphicsImageRendererFormat.default()
+        }
+        format.scale = 1
+        format.opaque = true
+        if #available(iOS 12.0, *) {
+            format.preferredRange = .extended
+        } else {
+            format.prefersExtendedRange = false
+        }
+        return format
     }
 }

--- a/Sources/AnyImageKit/Editor/Protocol/EditorPhotoResource.swift
+++ b/Sources/AnyImageKit/Editor/Protocol/EditorPhotoResource.swift
@@ -129,7 +129,6 @@ extension EditorPhotoResource {
             canvasSize = canvasSize.reversed(isLandscapeMode)
             imageSize = imageSize.reversed(isLandscapeMode)
         }
-        print(Date().timeIntervalSince1970)
         
         // Correcting image orientation
         let fixedImage = UIGraphicsImageRenderer.init(size: canvasSize, format: getImageRendererFormat()).image { rendererContext in

--- a/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
+++ b/Sources/AnyImageKit/Picker/Controller/AssetPickerViewController.swift
@@ -544,7 +544,7 @@ extension AssetPickerViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let asset = album?.assets[indexPath.item] else { return UICollectionViewCell() }
+        guard let asset = album?.assets[indexPath.item] else { return collectionView.dequeueReusableCell(UICollectionViewCell.self, for: indexPath) }
         
         #if ANYIMAGEKIT_ENABLE_CAPTURE
         if asset.isCamera {


### PR DESCRIPTION
Fix the issue where the orientation of an image is not correctly handled when the EXIF data contains information about it.

Editor will fix the orientation and rotate the image to be upright before editing.

Ref: https://magnushoff.com/articles/jpeg-orientation/